### PR TITLE
Explicitly specify utf8 for decode()

### DIFF
--- a/dogesay/script.py
+++ b/dogesay/script.py
@@ -10,7 +10,7 @@ parser.add_argument("clauses", nargs="*",
 def main():
     args            = parser.parse_args()
     doge_face_data  = pkgutil.get_data("dogesay", "static/doge.txt")
-    doge_face_lines = doge_face_data.decode().split("\n")
+    doge_face_lines = doge_face_data.decode('utf8').split("\n")
 
     clauses_source  = args.clauses if args.file == None else open(args.file, "r")
 


### PR DESCRIPTION
If the default encoding is not UTF8, you can get errors like 'ASCII cannot decode character <blah>' when reading the doge. Specifying it explicitly avoids this problem.